### PR TITLE
Fix serialization for embeds

### DIFF
--- a/src/lexicon/app/bsky/feed.rs
+++ b/src/lexicon/app/bsky/feed.rs
@@ -57,6 +57,7 @@ pub struct Post {
     #[serde(rename(deserialize = "$type", serialize = "$type"))]
     pub rust_type: Option<String>,
     pub text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub embed: Option<Embeds>,
 }
 
@@ -143,5 +144,3 @@ pub struct GetLikesOutput {
     pub likes: Vec<GetLikesLike>,
     pub cursor: Option<String>
 }
-
-


### PR DESCRIPTION
thank you @jesopo for suggesting this

Without this, creating posts won't work:

```text
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: ApiError(ApiError { error: "InvalidRequest", message: "Invalid app.bsky.feed.post record: Record/embed must be an object which includes the \"$type\" property" })'
```

this is because before this patch, it would serialize like this:

```text
BODY: "{\"repo\":\"did:plc:3danwc67lo7obz2fmdg6jxcr\",\"collection\":\"app.bsky.feed.post\",\"record\":{\"createdAt\":\"2023-05-01T23:48:17.986150300Z\",\"$type\":\"app.bsky.feed.post\",\"text\":\"is this thing on\",\"embed\":null}}"
```

rather than sending a null embed, we just shouldn't send it at all.